### PR TITLE
Fixed ffi loading issue on Mac OS X (Mojave)

### DIFF
--- a/rtmidi/main.rkt
+++ b/rtmidi/main.rkt
@@ -17,7 +17,19 @@
          rtmidi-close-port
          rtmidi-send-message)
 
-(define-ffi-definer define-rtmidi (ffi-lib "wrap-rtmidi"))
+;; On Mac OSX opening the wrapper with (ffi-lib "wrap-rtmidi") makes
+;; Racket look for the dylib in the directory of the main script that
+;; is running instead of in the directory of the module. This fixes
+;; that.
+(define-values (package-path script-name irrelevant )
+  (split-path
+   (resolved-module-path-name
+    (variable-reference->resolved-module-path
+     (#%variable-reference)))))
+
+(define lib-path (build-path package-path "wrap-rtmidi"))
+
+(define-ffi-definer define-rtmidi (ffi-lib lib-path))
 
 (define _rtmidi_in-pointer  (_cpointer 'rtmidi_in))
 (define _rtmidi_out-pointer (_cpointer 'rtmidi_out))

--- a/rtmidi/main.rkt
+++ b/rtmidi/main.rkt
@@ -8,6 +8,7 @@
          ffi/unsafe/custodian
          racket/async-channel
          racket/pretty
+         racket/runtime-path
          (rename-in racket/contract [-> ->/c]))
 
 (provide make-rtmidi-in
@@ -17,19 +18,8 @@
          rtmidi-close-port
          rtmidi-send-message)
 
-;; On Mac OSX opening the wrapper with (ffi-lib "wrap-rtmidi") makes
-;; Racket look for the dylib in the directory of the main script that
-;; is running instead of in the directory of the module. This fixes
-;; that.
-(define-values (package-path script-name irrelevant )
-  (split-path
-   (resolved-module-path-name
-    (variable-reference->resolved-module-path
-     (#%variable-reference)))))
-
-(define lib-path (build-path package-path "wrap-rtmidi"))
-
-(define-ffi-definer define-rtmidi (ffi-lib lib-path))
+(define-runtime-path wrap-rtmidi "wrap-rtmidi")
+(define-ffi-definer define-rtmidi (ffi-lib wrap-rtmidi))
 
 (define _rtmidi_in-pointer  (_cpointer 'rtmidi_in))
 (define _rtmidi_out-pointer (_cpointer 'rtmidi_out))


### PR DESCRIPTION
See comment in code. On Mac OS X Mojave (ffi-lib "wrap-rtmidi") tries to load wrap-rtmidi.dylib from the directory of the file that requires rtmidi instead of from the directory where rtmidi/main.rkt is stored.

One solution is to symlink wrap-rtmidi.dylib in the directory of your script. This is ugly. The other is to use this hack to force Racket to load the ffi-lib from the same directory as main.rkt. Which is also ugly, but more convenient.