### PR TITLE
Fix library loading on Linux

### DIFF
--- a/rtmidi/Makefile
+++ b/rtmidi/Makefile
@@ -13,7 +13,7 @@ macosx: LDFLAGS += -framework CoreMIDI -framework CoreAudio -framework CoreFound
 macosx: wrap-rtmidi.dylib
 
 wrap-rtmidi.so: wrap-rtmidi.o rtmidi-2.1.0/RtMidi.o
-	$(CXX) $(LDFLAGS) -fPIC -shared -o $@ $^
+	$(CXX) -fPIC -shared -o $@ $^ $(LDFLAGS)
 
 wrap-rtmidi.dylib: wrap-rtmidi.so
 	ln -fs wrap-rtmidi.so wrap-rtmidi.dylib


### PR DESCRIPTION
After following the directions and building the rtmidi wrapper on Linux
I get the following error:

```
$ racket
Welcome to Racket v7.8 [cs].
> (require rtmidi)
; ffi-lib: could not load foreign library
;   path: /home/sam/.racket/7.8/pkgs/rtmidi/rtmidi/wrap-rtmidi.so
;   system error: /home/sam/.racket/7.8/pkgs/rtmidi/rtmidi/wrap-rtmidi.so:
;     undefined symbol: snd_seq_client_info_get_name
; [,bt for context]
```

Checking what libraries the so is linked to indicates that at least
libasound and libpthread are missing:
```
$ ldd wrap-rtmidi.so
	linux-vdso.so.1 (0x00007ffcd54f8000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f0d91c3f000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f0d91c24000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f0d91a32000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f0d918e3000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f0d91e50000)
```

Applying this change and rebuilding the so fixes it (see below) and the
module now loads correctly in Racket.
```
$ ldd wrap-rtmidi.so
	linux-vdso.so.1 (0x00007ffeac7ff000)
	libasound.so.2 => /lib/x86_64-linux-gnu/libasound.so.2 (0x00007fa81358a000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fa813567000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fa813386000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fa81336b000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fa813179000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fa81302a000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fa813022000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fa8136b1000)
```